### PR TITLE
Add KCD Munich presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ This repository provides some of the presentations we have been doing on CNOE.
 | 2024-04-PlatformEngineering-DevOpsDayRaleigh    | [pdf](2024-04-PlatformEngineering-DevOpsDayRaleigh.pdf)     | [pptx](2024-04-PlatformEngineering-DevOpsDayRaleigh.pptx)     |
 | 2024-01-CNOE-presentation-tag-app-delivery      | [pdf](2024-01-CNOE-presentation-tag-app-delivery.pdf)       | [pptx](2024-01-CNOE-presentation-tag-app-delivery.pptx)       |
 | 2024-03-CNOE-KubeconEU2024-Rapid-IDP-Development-And-Automated-Testing-At-Autodesk      | [pdf](2024-03-CNOE-KubeconEU2024-Rapid-IDP-Development-And-Automated-Testing-At-Autodesk.pdf)       | [pptx](2024-03-CNOE-KubeconEU2024-Rapid-IDP-Development-And-Automated-Testing-At-Autodesk.pptx)       |
+| 2024-07-KCD-Munich-Standardizing-Platforms | [pdf](2024-07-KCD-Munich-Standardizing-Platforms.pdf) | --- |


### PR DESCRIPTION
As promised, here's my slidedeck for KCD Munich, OpenInfraDay Berlin, and stackconf. This is the final version, used for KCD Munich.

If anyone knows of a good way to convert the PDF to pptx, I'd be happy to update the PR.